### PR TITLE
Added typesafe config options for setting some other cookie options

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -20,8 +20,19 @@ spray {
 
       timeout = 10 minutes
 
-      cookie-name = SPRAY_SESSION
+      cookie {
 
+        name = SPRAY_SESSION
+
+        domain = ""
+
+        path = ""
+
+        secure = false
+
+        httpOnly = false
+
+      }
     }
 
   }

--- a/src/main/scala/spray/routing/session/CookieBakerSessionManager.scala
+++ b/src/main/scala/spray/routing/session/CookieBakerSessionManager.scala
@@ -63,7 +63,7 @@ class CookieBakerSessionManager(config: Config)(implicit ec: ExecutionContext) e
     Future.successful(Map())
 
   def cookify(map: Map[String,String]): Future[HttpCookie] =
-   Future(HttpCookie(name = cookieName, content = encode(map), maxAge = maxAge))
+   Future(HttpCookie(name = cookieName, content = encode(map), maxAge = maxAge, path = cookiePath, domain = cookieDomain, secure = cookieSecure, httpOnly = cookieHttpOnly))
 
   val isSigned: Boolean =
     config.getBoolean("spray.routing.session.baker.signed")

--- a/src/main/scala/spray/routing/session/CookieManager.scala
+++ b/src/main/scala/spray/routing/session/CookieManager.scala
@@ -1,0 +1,44 @@
+package spray.routing.session
+
+import com.typesafe.config.Config
+import spray.http.HttpCookie
+
+import scala.concurrent.Future
+
+/**
+ * Common session cookie trait used in both stateful and stateless session managers
+ */
+trait CookieManager[T] {
+
+    /* needs a typesafe config to get the settings from */
+    def config : Config
+
+    /** The name of the session cookie, configured via configuration key `spray.routing.session.cookie.name` */
+    val cookieName: String =
+        config.getString("spray.routing.session.cookie.name")
+
+    /** The domain of the session cookie, configured via configuration key `spray.routing.session.cookie.domain` */
+    val cookieDomain: Option[String] =
+        config.getString("spray.routing.session.cookie.domain") match {
+            case s : String if !s.isEmpty()  => Some(s)
+            case _ => None
+        }
+
+    /** The path of the session cookie, configured via configuration key `spray.routing.session.cookie.path` */
+    val cookiePath: Option[String] =
+        config.getString("spray.routing.session.cookie.path") match {
+            case s : String if !s.isEmpty()  => Some(s)
+            case _ => None
+        }
+
+    /** Whether or not the session cookie will be secure, configured via configuration key `spray.routing.session.cookie.secure` */
+    val cookieSecure: Boolean =
+        config.getBoolean("spray.routing.session.cookie.secure")
+
+    /** Whether or not the session cookie will be http only, configured via configuration key `spray.routing.session.cookie.httpOnly` */
+    val cookieHttpOnly: Boolean =
+        config.getBoolean("spray.routing.session.cookie.httpOnly")
+
+    /** Returns the cookie value for the given session identifier */
+    def cookify(payload : T): Future[HttpCookie]
+}

--- a/src/main/scala/spray/routing/session/InMemorySessionManager.scala
+++ b/src/main/scala/spray/routing/session/InMemorySessionManager.scala
@@ -109,10 +109,10 @@ class InMemorySessionManager[T](config: Config)(implicit system: ActorSystem, ti
       case Cookify(id) =>
         sessions.get(id) match {
           case Some(sess @ Session(_, expires)) if expires.map(_ > DateTime.now).getOrElse(true) =>
-            sender ! HttpCookie(name = cookieName, content = id, expires = expires, path = None)
+            sender ! HttpCookie(name = cookieName, content = id, expires = expires, path = cookiePath, domain = cookieDomain, secure = cookieSecure, httpOnly = cookieHttpOnly)
           case None | Some(_) =>
             // unknown session or expired session
-            sender ! HttpCookie(name = cookieName, content = "", maxAge = Some(-1), path = None)
+            sender ! HttpCookie(name = cookieName, content = "", maxAge = Some(-1), path = cookiePath, domain = cookieDomain, secure = cookieSecure, httpOnly = cookieHttpOnly)
 
         }
 

--- a/src/main/scala/spray/routing/session/RedisSessionManager.scala
+++ b/src/main/scala/spray/routing/session/RedisSessionManager.scala
@@ -100,12 +100,12 @@ class RedisSessionManager[T](config: Config)(
       yield
         if(maxAge <= -2)
           // unknown session
-          HttpCookie(name = cookieName, content = "", maxAge = Some(-1))
+          HttpCookie(name = cookieName, content = "", maxAge = Some(-1), path = cookiePath, domain = cookieDomain, secure = cookieSecure, httpOnly = cookieHttpOnly )
         else if(maxAge == -1)
           // no ttl for this key
-          HttpCookie(name = cookieName, content = id)
+          HttpCookie(name = cookieName, content = id, path = cookiePath, domain = cookieDomain, secure = cookieSecure, httpOnly = cookieHttpOnly )
         else
-          HttpCookie(name = cookieName, content = id, maxAge = Some(maxAge))
+          HttpCookie(name = cookieName, content = id, maxAge = Some(maxAge), path = cookiePath, domain = cookieDomain, secure = cookieSecure, httpOnly = cookieHttpOnly )
 
   /** This operation is not supported for Redis session manager */
   def onInvalidate(callback: (String, Map[String, T]) => Unit): Unit =

--- a/src/main/scala/spray/routing/session/StatefulSessionManager.scala
+++ b/src/main/scala/spray/routing/session/StatefulSessionManager.scala
@@ -34,7 +34,7 @@ import com.typesafe.config.Config
  *
  *  @author Lucas Satabin
  */
-abstract class StatefulSessionManager[T](val config: Config) {
+abstract class StatefulSessionManager[T](val config: Config) extends CookieManager[String] {
 
   private val alpha = "abcdefghijklmnopqrstuvwxyz"
   private val symbols = alpha + alpha.toUpperCase + "0123456789/=?+-_:"
@@ -42,9 +42,6 @@ abstract class StatefulSessionManager[T](val config: Config) {
   private val idLength = 16
   private val random = new java.security.SecureRandom
 
-  /** The name of the session cookie, configured via configuration key `spray.routing.session.cookie-name` */
-  val cookieName: String =
-    config.getString("spray.routing.session.cookie-name")
 
   /** The duration of a session, configured via configuration key `spray.routing.session.timeout` */
   val sessionTimeout: Duration =
@@ -73,7 +70,7 @@ abstract class StatefulSessionManager[T](val config: Config) {
   def invalidate(id: String): Future[Unit]
 
   /** Returns the cookie value for the given session identifier */
-  def cookify(id: String): Future[HttpCookie]
+  def cookify(payload: String): Future[HttpCookie]
 
   /** Registers a callback that gets called whenever a session is invalidated.
    *  This feature may not be present with all implementations, please refer

--- a/src/main/scala/spray/routing/session/StatelessSessionManager.scala
+++ b/src/main/scala/spray/routing/session/StatelessSessionManager.scala
@@ -33,11 +33,7 @@ import com.typesafe.config.Config
  *
  *  @author Lucas Satabin
  */
-abstract class StatelessSessionManager[T](val config: Config) {
-
-  /** The name of the session cookie, configured via configuration key `spray.routing.session.cookie-name` */
-  val cookieName: String =
-    config.getString("spray.routing.session.cookie-name")
+abstract class StatelessSessionManager[T](val config: Config) extends CookieManager[Map[String,T]] {
 
   /** The duration of a session, configured via configuration key `spray.routing.session.timeout` */
   val sessionTimeout: Duration =


### PR DESCRIPTION
Needed to add path and domain options for the session cookie, added secure and httpOnly as well.

This isn't 100% tested, but before I do, would you rather have the cookie stuff pulled out into a trait since stateless and stateful both use the same?
