### PR TITLE
Added call to redis AUTH command on RedisSessionManger construction

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,6 +10,8 @@ spray {
 
         port = 6379
 
+        password = ""
+
       }
 
       baker {

--- a/src/main/scala/spray/routing/session/RedisSessionManager.scala
+++ b/src/main/scala/spray/routing/session/RedisSessionManager.scala
@@ -59,6 +59,15 @@ class RedisSessionManager[T](config: Config)(
       host = config.getString("spray.routing.session.redis.host"),
       port = config.getInt("spray.routing.session.redis.port"))
 
+  private val password = config.getString("spray.routing.session.redis.password")
+
+  if(password.length > 0){
+    client.auth(password).onFailure{
+      throw new ExceptionInInitializerError("redis AUTH command failed, is config spray.routing.session.redis.password correct?")
+    }
+  }
+
+
   def start(): Future[String] = {
     val id = newSid
     for {


### PR DESCRIPTION
For cases where redis is behind a password, I added an auth call in the constructor, maybe there's a smarter way to do this without trying the auth straight away?
