### PR TITLE
Scala/SBT/library version bumps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,44 +1,23 @@
 name := "spray-session"
-
 organization := "org.gnieh"
-
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.11.2"
+crossScalaVersions := Seq("2.11.7", "2.10.6")
+scalaVersion := crossScalaVersions.value.head
 
-crossScalaVersions := Seq("2.11.2", "2.10.4")
-
-libraryDependencies += "io.spray" %% "spray-json" % "1.3.0" % "optional"
-
-libraryDependencies += "io.spray" %% "spray-routing" % "1.3.2"
-
-libraryDependencies += "io.spray" %% "spray-testkit" % "1.3.2" % "test"
-
-libraryDependencies += "org.specs2" %% "specs2" % "2.3.13" % "test"
-
-libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.3.5" % "provided, test"
-
-libraryDependencies += "net.debasishg" %% "redisreact" % "0.7" % "optional"
-
-scalacOptions ++= Seq("-deprecation", "-feature")
-
-osgiSettings
-
-OsgiKeys.exportPackage := Seq(
-  "spray.routing.session.directives",
-  "spray.routing.session"
+libraryDependencies ++= Seq(
+  "io.spray" %% "spray-json" % "1.3.2" % "optional",
+  "io.spray" %% "spray-routing" % "1.3.3",
+  "io.spray" %% "spray-testkit" % "1.3.3" % "test",
+  "org.specs2" %% "specs2-core" % "2.4.17" % "test",
+  "com.typesafe.akka" %% "akka-actor" % "2.3.14" % "provided, test",
+  "net.debasishg" %% "redisreact" % "0.8" % "optional"
 )
 
-OsgiKeys.importPackage := Seq(
-  "com.redis;resolution:=optional",
-  "com.redis.*;resolution:=optional",
-  "*"
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding", "UTF-8",
+  "-feature",
+  "-unchecked",
+  "-Xlint"
 )
-
-OsgiKeys.additionalHeaders := Map (
-  "Bundle-Name" -> "Session Management for Spray"
-)
-
-OsgiKeys.bundleSymbolicName := "org.gnieh.spray.session"
-
-OsgiKeys.privatePackage := Seq()

--- a/osgi.sbt
+++ b/osgi.sbt
@@ -1,0 +1,19 @@
+osgiSettings
+
+OsgiKeys.exportPackage := Seq(
+  "spray.routing.session.directives",
+  "spray.routing.session"
+)
+
+OsgiKeys.importPackage := Seq(
+  "com.redis;resolution:=optional",
+  "com.redis.*;resolution:=optional",
+  "*"
+)
+
+OsgiKeys.additionalHeaders := Map (
+  "Bundle-Name" -> "Session Management for Spray"
+)
+
+OsgiKeys.bundleSymbolicName := "org.gnieh.spray.session"
+OsgiKeys.privatePackage := Seq()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.9

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,40 +1,24 @@
 spray {
-
   routing {
-
     session {
-
       redis {
-
         host = localhost
-
         port = 6379
-
       }
 
       baker {
-
         signed = false
-
       }
 
       timeout = 10 minutes
 
       cookie {
-
         name = SPRAY_SESSION
-
         domain = ""
-
         path = ""
-
         secure = false
-
         httpOnly = false
-
       }
     }
-
   }
-
 }

--- a/src/main/scala/spray/routing/session/InMemorySessionManager.scala
+++ b/src/main/scala/spray/routing/session/InMemorySessionManager.scala
@@ -121,12 +121,12 @@ class InMemorySessionManager[T](config: Config)(implicit system: ActorSystem, ti
           case Some(Session(_, Some(expires))) if expires > DateTime.now =>
             // only update a session if it exists and is valid
             context.become(running(sessions.updated(id, Session(map, Some(restamp))), callbacks))
-            sender ! ()
+            sender ! (())
 
           case Some(Session(_, None)) =>
             // no expiration, always valid
             context.become(running(sessions.updated(id, Session(map, None)), callbacks))
-            sender ! ()
+            sender ! (())
 
           case None | Some(_) =>
             // unknown or expired session
@@ -143,7 +143,7 @@ class InMemorySessionManager[T](config: Config)(implicit system: ActorSystem, ti
           for(callback <- callbacks)
             callback(id, sessions(id).map)
 
-        sender ! ()
+        sender ! (())
 
       case OnInvalidate(callback) =>
         // register the callback

--- a/src/test/scala/spray/routing/session/StatefulSessionSpec.scala
+++ b/src/test/scala/spray/routing/session/StatefulSessionSpec.scala
@@ -42,7 +42,7 @@ abstract class StatefulSessionSpec extends Specification with Specs2RouteTest {
 
     val invalidSessionHandler = RejectionHandler {
       case InvalidSessionRejection(id) :: _ =>
-        complete(Unauthorized, s"Unknown session $id")
+        complete((Unauthorized, s"Unknown session $id"))
     }
 
     // create a new manager for each scope

--- a/src/test/scala/spray/routing/session/StatelessSessionSpec.scala
+++ b/src/test/scala/spray/routing/session/StatelessSessionSpec.scala
@@ -42,7 +42,7 @@ abstract class StatelessSessionSpec extends Specification with Specs2RouteTest {
 
     val invalidSessionHandler = RejectionHandler {
       case InvalidSessionRejection(id) :: _ =>
-        complete(Unauthorized, s"Unknown session $id")
+        complete((Unauthorized, s"Unknown session $id"))
     }
 
     // create a new manager for each scope


### PR DESCRIPTION
Bumped Scala to 2.11.7, 2.10.6
Bumped SBT to 0.13.9
Bumped library dependencies to latest (except Specs2 2.x, Akka 2.3.x)
Removed some tuple assembly warnings.

---

As of SBT 0.13.9 it is no longer necessary to separate `build.sbt` settings with a newline.

Akka 2.4.0 is now available; but only for Scala 2.11.x and the project doesn't compile without modifications.

[Specs2 3.x is not compatible with spray](https://groups.google.com/forum/#!topic/spray-user/2T6SBp4OJeI), so it was bumped to latest in the 2.x branch (2.4.17)
